### PR TITLE
include client in __dict__ for a project and associated object

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See [the Optimizely REST API documentation](http://developers.optimizely.com/res
 # {
 #   'id': 1234,
 #   'account_id': 123456789,
+#   'client': <optimizely.client.Client object at 0x7c11e6fa7090>,
 #   'code_revision': 12,
 #   'project_name': 'My even newer project name',
 #   'project_status': 'Active',


### PR DESCRIPTION
While using the python client, I realized that there was a python object in the __dict__ for a project. This explained why I was seeing errors such as "client object at [object id] is not JSON serializable". Just updated the README to include this info.