### PR TITLE
Fix bug where experiment id's > MAXINT will not be requested

### DIFF
--- a/optimizely/resource.py
+++ b/optimizely/resource.py
@@ -16,7 +16,7 @@ class ResourceGenerator(object):
   def get(self, optimizely_ids=None):
     if not optimizely_ids:
       return self.resource.list(client=self.client)
-    elif type(optimizely_ids) == int:
+    elif type(optimizely_ids) == int or type(optimizely_ids) == long:
       instance = self.resource(self.client, optimizely_id=optimizely_ids)
       instance.refresh()
       return instance


### PR DESCRIPTION
Currently, if we do something like:
 `e = client.Experiments.get(2948090296)`, nothing will get requested. 

This is because `ResourceGenerator.get()` only previously checked if `type(optimizely_ids) == int`. Once we get numbers higher than MAXINT, Python will make the type `long`, which means no if branch will get ran. This PR will make sure all int/long types are treated the same.

I believe this will fix open issue: https://github.com/optimizely/optimizely-client-python/issues/9

@aliabbasrizvi  @jgaul @lucasoptimizely Who is the owner of this client now?