### PR TITLE
Added experiment_type to Experiment.editable_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ Experiments can be updated by updating the attributes of a fetched object and ca
 * `custom_js`
 * `percentage_included`
 * `url_conditions`
+* `experiment_type`
 
-We don't currently support creating or updating multivariate or multipage tests via the API.
 
 ####Example Python
 ```python

--- a/optimizely/resource.py
+++ b/optimizely/resource.py
@@ -170,7 +170,8 @@ class Experiment(CreatableChildObject, UpdatableObject, DeletableObject):
                      'custom_css',
                      'custom_js',
                      'percentage_included',
-                     'url_conditions']
+                     'url_conditions',
+                     'experiment_type']
 
   def results(self):
     return self.get_child_objects(Result)

--- a/optimizely/resource.py
+++ b/optimizely/resource.py
@@ -172,17 +172,17 @@ class Project(ListableObject, CreatableObject, UpdatableObject):
 
 
 class Experiment(CreatableChildObject, UpdatableObject, DeletableObject):
-  parent_resource = Project
-  editable_fields = ['audience_ids',
-                     'activation_mode',
-                     'description',
-                     'edit_url',
-                     'status',
-                     'custom_css',
-                     'custom_js',
-                     'percentage_included',
-                     'url_conditions',
-                     'experiment_type']
+    parent_resource = Project
+    editable_fields = ['audience_ids',
+                       'activation_mode',
+                       'description',
+                       'edit_url',
+                       'status',
+                       'custom_css',
+                       'custom_js',
+                       'percentage_included',
+                       'url_conditions',
+                       'experiment_type']
 
     def results(self):
         return self.get_child_objects(Result)


### PR DESCRIPTION
## Add ability to edit experiment_type for project experiments.

I found that this feature is working using `curl` and trying to sync python client.